### PR TITLE
Increased the minimum request size for an avatar

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@ respond('/[avatar|head]/[:username].[:format]?/[:size]?.[:formate]?', function (
 	$ext  = $request->param('formate', '.png');
 	list($name) = explode('.', $name);
 	list($size) = explode('.', $size);
-	$size = min(1000, max(1, (int) $size));
+	$size = min(1000, max(16, (int) $size));
 
 	$name = Minotar::get($name);
 
@@ -29,7 +29,7 @@ respond('/helm/[:username].[:format]?/[:size]?.[:formate]?', function ($request,
 	$ext  = $request->param('formate', '.png');
 	list($name) = explode('.', $name);
 	list($size) = explode('.', $size);
-	$size = min(1000, max(1, (int) $size));
+	$size = min(1000, max(16, (int) $size));
 
 	$name = Minotar::get($name);
 
@@ -44,7 +44,7 @@ respond('/[player|body]/[:username].[:format]?/[:size]?.[:formate]?', function (
 	$ext  = $request->param('formate', '.png');
 	list($name) = explode('.', $name);
 	list($size) = explode('.', $size);
-	$size = min(1000, max(1, (int) $size));
+	$size = min(1000, max(16, (int) $size));
 
 	$name = Minotar::get($name);
 
@@ -56,7 +56,7 @@ respond('/random/[:size]?.[:format]?', function ($request, $response) {
 	$size = $request->param('size', 180);
 	$ext  = $request->param('format', '.png');
 	list($size) = explode('.', $size);
-	$size = min(1000, max(1, (int) $size));
+	$size = min(1000, max(16, (int) $size));
 
 	$avatars = scandir('./minecraft/heads/');
 	$rand = array_rand($avatars);


### PR DESCRIPTION
Realistically, nobody is going to want or need an avatar smaller than 16 pixels.

I chose 16 pixels simply because that is the size of a favicon, which is more than likely the smallest possibly use case for this service.
