### PR TITLE
Fix helmets that are completely solid, but not completely white/transparent/black

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,15 +39,23 @@ respond('/helm/[:username].[:format]?/[:size]?.[:formate]?', function ($request,
 
     $name = Minotar::get($name);
 
-    $head = WideImage::load("./minecraft/heads/$name.png")->resize($size);
-    $helm = WideImage::load("./minecraft/helms/$name.png")->resize($size);
+    $head = WideImage::load("./minecraft/heads/$name.png");
+    $helm = WideImage::load("./minecraft/helms/$name.png");
 
-    if($helm->isTransparent())
-        $result = $head->merge($helm);
-    else
+    for ($x = 0; $x < $helm->getWidth(); $x++) {
+        for ($y = 0; $y < $helm->getHeight(); $y++) {
+            $color = $helm->getColorAt($x, $y);
+            if($color == PHP_INT_MAX || $color == 0 || $color == (256*256*256*127))
+                    $pixels++;
+        }
+    }
+
+    if($pixels == $head->getWidth() * $head->getHeight())
         $result = clone $head;
+    else
+        $result = $head->merge($helm);
 
-    $result->output($ext);
+    $result->resize($size)->output($ext);
 });
 
 respond('/[player|body]/[:username].[:format]?/[:size]?.[:formate]?', function ($request, $response) {


### PR DESCRIPTION
I tested quite a few helmets and they all worked on my last PR, but it turns out that I missed a few side cases. For example, someone might have a helmet that is completely solid, but they still want displayed (example: https://minotar.net/skin/zappad)

The only way to fix this is to check every pixel (64 in total, 8x8). If the pixel is either white, completely transparent, or black, then `n` is incremented. After checking all pixels, if `n` is equal to 64, then we shouldn't display the helmet because it most likely isn't suppoused to be displayed.

Once again, tested on Ubuntu 12.04, PHP5, latest WideImage stable. I tested well over 50 avatars that were side cases last time and they're all fixed with this change.
