### PR TITLE
Add .gitignore and create installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Compiled, pre-install files
 /minotar
+/minotar.exe
+
 /pkg
 /src

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Need Steve? Use "char" as the username:
 Installation is simple - however it requires an installation of [Go](http://golang.org). Follow the instructions below for a comprehensive, step by step installation.
 ```bash
 $ git clone https://github.com/minotar/minotar
+$ cd minotar
 
 $ export GOPATH=`pwd`
 $ go get


### PR DESCRIPTION
This pull request primarily does two things:
- Completes a `.gitignore` for active development by ignoring `minotar` (compiled executable), `/pkg/` (golang OS-specific files), and `/src/` (used for holding the dependencies locally).
- Completes the step by step installation instructions on the README.md. This way, it makes it easier and simpler for server owners to host their own Minotar version and reduce the stress on the primary server/s.

Enjoy. :+1: 
