### PR TITLE
Fixes #62 - adds MCGamer [MinecraftSurvivalGames] to the list

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -174,6 +174,9 @@
         <li><a href="http://massivecraft.com/">MassiveCraft</a><br>
             Massivecraft is a medieval fantasy role-playing Minecraft server.
         </li>
+        <li><a href="http://minecraftsurvivalgames.com/">Minecraft Survival Games</a><br>
+            Minecraft Survival Games is a dedicated Hunger Games server.
+        </li>
     </ul>
 
     <br>


### PR DESCRIPTION
This commit fixes issue [#62](https://github.com/minotar/minotar/issues/62), which is to add MCGamer to the list.

[MCGamer.net](http://mcgamer.net) redirects to Minecraft Survival Games.
