### PR TITLE
Resize for a 8 pixel image

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func fetchImageProcessThen(callback func(minecraft.Skin) (image.Image, error)) f
 		
 		imgResized := img
 		if vars["size"]  < "8" {
-			imgResized := Resize(size, size, img)
+			imgResized = Resize(size, size, img)
 			//imgResized = Resize(size, img)
 		}
 		


### PR DESCRIPTION
By default the images are alredy 8p so there is no need to pass them to imResized().
Also the with and height are the same. Yo going to implement rectangle heads ? if not i think there is no need for the extra variable on the funtion.
