### PR TITLE
https://minotar.net/ redirect requires a 302

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func main() {
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Location", "https://minotar.net/")
+		w.WriteHeader(302)
 	})
 
 	http.Handle("/", r)


### PR DESCRIPTION
For the redirect to work, it requires a 302 status header. 
