### PR TITLE
Add caching layer for skins

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"github.com/minotar/minecraft"
+)
+
+const (
+	// Get the skin size in bytes. Skins have an 8-bit channel depth and are
+	// 64x32 pixels. Maximum of 8*64*32 plus 13 bytes for png metadata. They'll
+	// rarely (never) be that large due to compression, but we'll leave some
+	// extra wiggle to account for map overhead.
+	SKIN_SIZE = 8 * (64 * 32)
+
+	// Define a 64 MB cache size.
+	CACHE_SIZE = 2 << 25
+
+	// Based off those, calculate the maximum number of skins we'll store
+	// in memory.
+	SKIN_NUMBER = CACHE_SIZE / SKIN_SIZE
+)
+
+// Find the position of a string in a slice. Returns -1 on failure.
+func indexOf(str string, list []string) int {
+	for index, value := range list {
+		if value == str {
+			return index
+		}
+	}
+
+	return -1
+}
+
+// Cache object that stores skins in memory.
+type Cache struct {
+	// Map of usernames to minecraft skins. Lookups here are O(1), so that
+	// makes my happy.
+	Skins map[string]minecraft.Skin
+	// Additionally keep a *slice* of usernames which we can update
+	Usernames []string
+}
+
+func MakeCache() *Cache {
+	cache := Cache{}
+	cache.Skins = map[string]minecraft.Skin{}
+	cache.Usernames = []string{}
+
+	return &cache
+}
+
+// Returns whether the item exists in the cache.
+func (c *Cache) has(username string) bool {
+	if _, exists := c.Skins[username]; exists {
+		return true
+	} else {
+		return false
+	}
+}
+
+// Retrieves the item from the cache. We'll promote it to the "top" of the
+// cache, effectively updating its expiry time.
+func (c *Cache) pull(username string) minecraft.Skin {
+	index := indexOf(username, c.Usernames)
+	c.Usernames = append(c.Usernames, username)
+	c.Usernames = append(c.Usernames[:index], c.Usernames[index+1:]...)
+
+	return c.Skins[username]
+}
+
+// Adds the skin to the cache, remove the oldest, expired skin if the cache
+// list is full.
+func (c *Cache) add(username string, skin minecraft.Skin) {
+	if len(c.Usernames) >= SKIN_NUMBER {
+		first := c.Usernames[0]
+		delete(c.Skins, first)
+		c.Usernames = append(c.Usernames[1:], username)
+	} else {
+		c.Usernames = append(c.Usernames, username)
+	}
+
+	c.Skins[username] = skin
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ const (
 
 var (
 	ListenOn = ":9999"
+	cache    = MakeCache()
 )
 
 type NotFoundHandler struct{}
@@ -142,12 +143,17 @@ func downloadPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func fetchSkin(username string) minecraft.Skin {
+	if cache.has(username) {
+		return cache.pull(username)
+	}
+
 	skin, err := minecraft.FetchSkinFromUrl(username)
 	if err != nil {
 		log.Error("Failed to get skin for " + username + " from Mojang (" + err.Error() + ")")
 		skin, _ = minecraft.FetchSkinForChar()
 	}
 
+	cache.add(username, skin)
 	return skin
 
 	/* We're not using this for now due to rate limiting restrictions


### PR DESCRIPTION
Added basic in-memory caching of avatars, which is quite fast and would help out a bit for serving the most viewed avatars. Set a rough limit of 64 MB of in-memory cached data.

```
Looking at response times, running Siege on a Macbook Air.

============================================================
Response time before caching was added:

For all requests: 0.082 secs

============================================================
Response time after caching was added:

Getting the same avatar 100 times: 0.014 secs # best case, >4x increase in speed!
Getting a unique avatar 100 times: 0.083 secs # worse case -, not much different from before caching
Getting the same set of 10 avatars 1000 times: 0.013 secs

============================================================
Letting it run and taking a nap, peak memory usage in caching. Expected
it to peak around 64 MB. Looks like there's actually a memory issue elsewhere.
Increased ad infinitum, even on the current master branch without my caching addition.

============================================================
Am now banned from Mojang API: definitely.
```

The timings in the request log makes me much more happy than before :)

```
[15:25:36.474659] INFO Serving skin for connor4312 (184+0+6=191ms) md5: d05a3eda6f8b1d3b8dfae6315c3aae65
[15:25:37.165298] INFO Serving skin for connor4312 (0+0+5=5ms) md5: d05a3eda6f8b1d3b8dfae6315c3aae65
[15:25:37.442426] INFO Serving skin for connor4312 (0+0+4=4ms) md5: d05a3eda6f8b1d3b8dfae6315c3aae65
[15:25:37.710710] INFO Serving skin for connor4312 (0+0+4=4ms) md5: d05a3eda6f8b1d3b8dfae6315c3aae65
[15:25:37.979408] INFO Serving skin for connor4312 (0+0+4=4ms) md5: d05a3eda6f8b1d3b8dfae6315c3aae65
```
