### PR TITLE
Faster drawing function

### DIFF
--- a/process.go
+++ b/process.go
@@ -136,8 +136,6 @@ func cropHead(img image.Image) image.Image {
 func cropHelm(img image.Image) image.Image {
 	headImg := cropHead(img)
 	helmImg := imaging.Crop(img, image.Rect(HelmX, HelmY, HelmX+HelmWidth, HelmY+HelmHeight))
-	// sr := helmImg.Bounds()
-	// draw.Draw(headImg.(*image.NRGBA), sr, helmImg, sr.Min, draw.Over)
 
 	fastDraw(headImg.(*image.NRGBA), helmImg, 0, 0)
 
@@ -145,7 +143,6 @@ func cropHelm(img image.Image) image.Image {
 }
 
 func fastDraw(dst *image.NRGBA, src *image.NRGBA, x, y int) {
-	// bounds := src.Bounds()
 	bounds := src.Bounds()
 	maxY := bounds.Max.Y
 	maxX := bounds.Max.X * 4
@@ -159,7 +156,7 @@ func fastDraw(dst *image.NRGBA, src *image.NRGBA, x, y int) {
 				dst.Pix[dstPx+0] = src.Pix[srcPx+0]
 				dst.Pix[dstPx+1] = src.Pix[srcPx+1]
 				dst.Pix[dstPx+2] = src.Pix[srcPx+2]
-				dst.Pix[dstPx+3] = 255
+				dst.Pix[dstPx+3] = 0xFF
 			}
 		}
 	}


### PR DESCRIPTION
Go's draw function has to take into account alpha transparency and blending when drawing images, but Minecraft skins don't have partially transparent components. With this knowledge, we can create a simpler, faster function, with a speed increase up to 5x in some cases.

```
Before:
BenchmarkSetup  2000000000           0.00 ns/op
BenchmarkGetHead     2000000           843 ns/op
BenchmarkGetHelm      200000         13064 ns/op
BenchmarkGetBody      100000         25182 ns/op
BenchmarkGetBust       50000         32185 ns/op

After:
BenchmarkSetup  2000000000           0.00 ns/op
BenchmarkGetHead     2000000           851 ns/op
BenchmarkGetHelm     1000000          2300 ns/op
BenchmarkGetBody      200000         12920 ns/op
BenchmarkGetBust      100000         14828 ns/op
```

And just for fun, when the benchmarks were first added two days ago :smile: 

```
BenchmarkGetHead      500000          6638 ns/op
BenchmarkGetHelm      200000          9264 ns/op
BenchmarkGetBody       50000         38927 ns/op
```
