### PR TITLE
Error handling for failed cache setup

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Cache interface {
-	setup()
+	setup() error
 	has(username string) bool
 	pull(username string) minecraft.Skin
 	add(username string, skin minecraft.Skin)

--- a/cache_memory.go
+++ b/cache_memory.go
@@ -38,11 +38,12 @@ func indexOf(str string, list []string) int {
 	return -1
 }
 
-func (c *CacheMemory) setup() {
+func (c *CacheMemory) setup() error {
 	c.Skins = map[string]minecraft.Skin{}
 	c.Usernames = []string{}
 
 	log.Info("Loaded Memory cache")
+	return nil
 }
 
 // Returns whether the item exists in the cache.

--- a/cache_off.go
+++ b/cache_off.go
@@ -7,8 +7,9 @@ import (
 type CacheOff struct {
 }
 
-func (c *CacheOff) setup() {
+func (c *CacheOff) setup() error {
 	log.Info("Loaded without cache")
+	return nil
 }
 
 func (c *CacheOff) has(username string) bool {

--- a/cache_redis.go
+++ b/cache_redis.go
@@ -31,7 +31,7 @@ func dialFunc(network, addr string) (*redis.Client, error) {
 	return client, nil
 }
 
-func (c *CacheRedis) setup() {
+func (c *CacheRedis) setup() error {
 	pool, err := pool.NewCustomPool(
 		"tcp",
 		config.Redis.Address,
@@ -40,12 +40,13 @@ func (c *CacheRedis) setup() {
 	)
 	if err != nil {
 		log.Error("Error connecting to redis database")
-		return
+		return err
 	}
 
 	c.Pool = pool
 
 	log.Info("Loaded Redis cache (pool: " + fmt.Sprintf("%v", config.Redis.PoolSize) + ")")
+	return nil
 }
 
 func (c *CacheRedis) getFromPool() *redis.Client {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,11 @@ func setupConfig() {
 
 func setupCache() {
 	cache = MakeCache(config.Server.Cache)
-	cache.setup()
+	err := cache.setup()
+	if err != nil {
+		log.Critical("Unable to setup Cache. (" + fmt.Sprintf("%v", err) + ")")
+		os.Exit(1)
+	}
 }
 
 func setupLog(logBackend *logging.LogBackend) {


### PR DESCRIPTION
Catch error and throw critical before exiting.

(useful if you forget to start Redis...)

```
ERRO Error connecting to redis database
CRIT Unable to setup Cache. (dial tcp 127.0.0.1:6379: connection refused)
```
