### PR TITLE
Emphasis crisp edges of SVG

### DIFF
--- a/process.go
+++ b/process.go
@@ -310,7 +310,7 @@ func (skin *mcSkin) WriteSVG(w io.Writer) error {
 	img := skin.Processed.(*image.NRGBA)
 
 	// Make a canvas the same size as the image.
-	canvas.Start(bounds.Max.X, bounds.Max.Y)
+	canvas.Start(bounds.Max.X, bounds.Max.Y, `shape-rendering="crispEdges"`)
 	// Loop through every pixel in the image.
 	for y := 0; y < bounds.Max.Y; y += 1 {
 		for x := 0; x < bounds.Max.X; x += 1 {


### PR DESCRIPTION
`crispEdges` prevent transparent lines between the 'pixels' when the SVG is scaled up.

(IE 11 seems to not have an issue with this, but Chrome does)

As reported in the PR: https://github.com/minotar/imgd/pull/137#issuecomment-68598831

![2015-01-03_19-53-04](https://cloud.githubusercontent.com/assets/799079/5603543/2a71c2fa-9382-11e4-8464-0144fb91b09f.png)

Should not be merged until @clone1018 is ready to adjust minotar.net backend.