### PR TITLE
Removed "Minotar" reference

### DIFF
--- a/config.example.gcfg
+++ b/config.example.gcfg
@@ -4,6 +4,8 @@ address = 0.0.0.0:8000
 # Cache you want to use for skins. May be "redis", "memory", or "off".
 # If it's Redis, you should fill out the [redis] section below.
 cache = memory
+# Address to redirect users to upon browsing /
+url = https://minotar.net/
 # Whether to store statistics about API usage. This requires a
 # redis connection if true (fill the config below).
 statisticsEnabled = false

--- a/config.example.gcfg
+++ b/config.example.gcfg
@@ -6,9 +6,6 @@ address = 0.0.0.0:8000
 cache = memory
 # Address to redirect users to upon browsing /
 url = https://minotar.net/
-# Whether to store statistics about API usage. This requires a
-# redis connection if true (fill the config below).
-statisticsEnabled = false
 # The duration, in seconds we should store item in our cache. Default: 48 hrs
 ttl = 172800
 

--- a/configuration.go
+++ b/configuration.go
@@ -17,11 +17,10 @@ const (
 
 type Configuration struct {
 	Server struct {
-		Address           string
-		Cache             string
-		URL               string
-		StatisticsEnabled bool
-		Ttl               int
+		Address string
+		Cache   string
+		URL     string
+		Ttl     int
 	}
 
 	Redis struct {

--- a/configuration.go
+++ b/configuration.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"code.google.com/p/gcfg"
 	"io"
 	"os"
+
+	"code.google.com/p/gcfg"
 )
 
 const (
@@ -18,6 +19,7 @@ type Configuration struct {
 	Server struct {
 		Address           string
 		Cache             string
+		URL               string
 		StatisticsEnabled bool
 		Ttl               int
 	}

--- a/http.go
+++ b/http.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/minotar/minecraft"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/minotar/minecraft"
 )
 
 type Router struct {
@@ -153,7 +154,7 @@ func (router *Router) Bind() {
 	router.Mux.HandleFunc("/skin/{username:"+minecraft.ValidUsernameRegex+"}{extension:(.png)?}", router.SkinPage)
 
 	router.Mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "%s", MinotarVersion)
+		fmt.Fprintf(w, "%s", ImgdVersion)
 	})
 
 	router.Mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +163,7 @@ func (router *Router) Bind() {
 	})
 
 	router.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "https://minotar.net/", 302)
+		http.Redirect(w, r, config.Server.URL, 302)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/op/go-logging"
 	"net/http"
 	"os"
 	"runtime"
+
+	"github.com/gorilla/mux"
+	"github.com/op/go-logging"
 )
 
 const (
@@ -22,7 +23,7 @@ const (
 	TimeoutActualSkin       = 2 * Days
 	TimeoutFailedFetch      = 15 * Minutes
 
-	MinotarVersion = "2.7"
+	ImgdVersion = "2.7"
 )
 
 var (


### PR DESCRIPTION
The version itself is referring to imgd and it makes sense to also allow configuration of the other Minotar reference - redirect address.

Also removes an unused part from config (may as well put the config changes together).