### PR TITLE
Show stats for number of cached skins

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,7 @@ type Cache interface {
 	has(username string) bool
 	pull(username string) minecraft.Skin
 	add(username string, skin minecraft.Skin)
+	size() uint
 	memory() uint64
 }
 

--- a/cache_memory.go
+++ b/cache_memory.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/minotar/minecraft"
 	"time"
+
+	"github.com/minotar/minecraft"
 )
 
 const (
@@ -94,6 +95,11 @@ func (c *CacheMemory) add(username string, skin minecraft.Skin) {
 	time.AfterFunc(time.Duration(config.Server.Ttl)*time.Second, func() {
 		c.remove(username)
 	})
+}
+
+// The exact number of usernames in the map
+func (c *CacheMemory) size() uint {
+	return uint(len(c.Usernames))
 }
 
 // The byte size of the cache. Fairly rough... don't really want to venture

--- a/cache_off.go
+++ b/cache_off.go
@@ -25,6 +25,10 @@ func (c *CacheOff) pull(username string) minecraft.Skin {
 func (c *CacheOff) add(username string, skin minecraft.Skin) {
 }
 
+func (c *CacheOff) size() uint {
+	return 0
+}
+
 func (c *CacheOff) memory() uint64 {
 	return 0
 }

--- a/status.go
+++ b/status.go
@@ -34,8 +34,10 @@ type StatusCollector struct {
 		CacheHits uint
 		// Number of times skins have failed to be served from the cache.
 		CacheMisses uint
-		// Size of cached skins
-		Cached uint64
+		// Number of skins in cache.
+		CacheSize uint
+		// Size of cache memory.
+		CacheMem uint64
 	}
 
 	// Unix timestamp the process was booted at.
@@ -98,7 +100,8 @@ func (s *StatusCollector) Collect() {
 
 	s.info.Memory = memstats.Alloc
 	s.info.Uptime = time.Now().Unix() - s.StartedAt
-	s.info.Cached = cache.memory()
+	s.info.CacheSize = cache.size()
+	s.info.CacheMem = cache.memory()
 }
 
 // Increments the request counter for the specific type of request.

--- a/status.go
+++ b/status.go
@@ -25,7 +25,7 @@ type statusCollectorMessage struct {
 type StatusCollector struct {
 	info struct {
 		// Number of bytes allocated to the process.
-		Memory uint64
+		ImgdMem uint64
 		// Time in seconds the process has been running for
 		Uptime int64
 		// Number of times a request type has been served.
@@ -98,7 +98,7 @@ func (s *StatusCollector) Collect() {
 	memstats := &runtime.MemStats{}
 	runtime.ReadMemStats(memstats)
 
-	s.info.Memory = memstats.Alloc
+	s.info.ImgdMem = memstats.Alloc
 	s.info.Uptime = time.Now().Unix() - s.StartedAt
 	s.info.CacheSize = cache.size()
 	s.info.CacheMem = cache.memory()


### PR DESCRIPTION
Rename `Cached` to `CacheMem` and add `CacheSize` which is the number of keys in the Redis/Memory slice.

Also renamed `Memory` to `ImgdMem` to better differentiate.