### PR TITLE
Release 2.8

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ const (
 	MinWidth     = uint(8)
 	MaxWidth     = uint(300)
 
-	ImgdVersion = "2.7"
+	ImgdVersion = "2.8"
 )
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func TestRenders(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		hash := hashRender(skin.Processed)
-		So(hash, ShouldEqual, "a579af057377c35cbd4e53ed6bc5f03e")
+		So(hash, ShouldEqual, "a253bb68f5ed938eb235ff1e3807940c")
 	})
 
 	Convey("GetBust should return a valid image", t, func() {


### PR DESCRIPTION
Release 2.8 includes a few config changes, bug fixes and minor features.

Summary of commits below:
* Removed old "X-Requested" and "X-Result" headers
* Record stats for Skins and Downloads as "Skin" being served 
* Output some useful information on start (listening address, Redis DB info)
* Remove the last references of "Minotar" and replace with "Imgd"
* Allow configuration of the redirect address
* Remove `statisticsEnabled` an unused config option
* Added a statistic for the number of cached skins (and differentiate more from the mem usage)
* Allow selecting a different Database when using Redis
* Removed old constants
* Change some references of size to width
* Fixed the estimation for the memory usage of the Memory cache
* Fixed gcfg repository and tests