### PR TITLE
Release 2.9.1

### DIFF
--- a/http.go
+++ b/http.go
@@ -143,6 +143,7 @@ func (router *Router) Serve(resource string) {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "500 internal server error")
 			log.Info(r.RemoteAddr + " " + r.RequestURI + " 500 " + skin.Skin.Source)
+			stats.Errored("InternalServerError")
 			return
 		}
 		router.writeType(vars["extension"], skin, w)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ const (
 	MinWidth     = uint(8)
 	MaxWidth     = uint(300)
 
-	ImgdVersion = "2.8"
+	ImgdVersion = "2.9.1"
 )
 
 var (

--- a/status.go
+++ b/status.go
@@ -29,7 +29,7 @@ type StatusCollector struct {
 		ImgdMem uint64
 		// Time in seconds the process has been running for
 		Uptime int64
-		// Number of times a request type has been requested.
+		// Number of times an error has been recorded.
 		Errored map[string]uint
 		// Number of times a request type has been requested.
 		Requested map[string]uint


### PR DESCRIPTION
Changes:

 * Configurable logging level (default in config is NOTICE, if not set will default to INFO) #123
   * DEBUG will show skin failures
   * INFO will log individual requests
   * NOTICE will show useful start information and be fairly quiet
 * Adjust the way stats are reported, add an errored section #159
   * Requested is recorded as soon as we establish what is desired (before anything is returned)
   * Errors are recorded when we fail to fetch a skin or we have an internal error
 * Add CORS headers to all responses #167
 * Handle "MHF_Steve" internally to deprecate "char" #149