### PR TITLE
fix: lower armor legs being swapped

### DIFF
--- a/pkg/processd/mcskin/mcskin.go
+++ b/pkg/processd/mcskin/mcskin.go
@@ -397,7 +397,7 @@ func (skin *McSkin) renderLowerArmor() *image.NRGBA {
 		rl2Img := imaging.Crop(skin.Image, image.Rect(Rl2X, Rl2Y, Rl2X+RlWidth, Rl2Y+RlHeight))
 		skin.removeAlpha(rl2Img)
 
-		return skin.drawLower(lowerArmorBodyImg, ll2Img, rl2Img)
+		return skin.drawLower(lowerArmorBodyImg, rl2Img, ll2Img)
 	}
 	return lowerArmorBodyImg
 }


### PR DESCRIPTION
Essentially the right and left leg are swapped

I checked the other methods and they pass in the right part first then left

 
closes #217 